### PR TITLE
recovery import removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/spacemeshos/smcli
 
 go 1.18
 
-require (
-	github.com/spacemeshos/ed25519-recovery v0.2.0
-	github.com/stretchr/testify v1.8.2
-)
+require github.com/stretchr/testify v1.8.2
 
 require github.com/rogpeppe/go-internal v1.9.0 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -132,7 +132,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -151,8 +151,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spacemeshos/ed25519-recovery v0.2.0 h1:Hm11YAyUs99ZeSg/QlC0UgcjPF5BG4OYjJshrMZVBHQ=
-github.com/spacemeshos/ed25519-recovery v0.2.0/go.mod h1:G+UrXxP8gldLwFS7XZZBD0sW9W11Am0H5U1H3gXu3BU=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -482,8 +480,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/wallet/bip32_ed25519_wrapper_test.go
+++ b/wallet/bip32_ed25519_wrapper_test.go
@@ -1,10 +1,10 @@
 package wallet_test
 
 import (
+	"crypto/ed25519"
 	"crypto/sha512"
 	"testing"
 
-	"github.com/spacemeshos/ed25519-recovery"
 	"github.com/spacemeshos/smcli/wallet"
 	"github.com/stretchr/testify/require"
 	"github.com/xdg-go/pbkdf2"
@@ -26,10 +26,6 @@ func TestNewMasterBIP32EDKeyPair(t *testing.T) {
 	sig := ed25519.Sign(ed25519.PrivateKey(masterKeyPair.Private), msg)
 	valid := ed25519.Verify(ed25519.PublicKey(masterKeyPair.Public), msg, sig)
 	require.True(t, valid)
-
-	extractedPub, err := ed25519.ExtractPublicKey(msg, sig)
-	require.NoError(t, err)
-	require.Equal(t, masterKeyPair.Public, wallet.PublicKey(extractedPub))
 }
 
 //func TestNewChildKeyPair(t *testing.T) {

--- a/wallet/bip32_ed25519_wrapper_test.go
+++ b/wallet/bip32_ed25519_wrapper_test.go
@@ -18,14 +18,27 @@ func generateTestMasterKeyPair() (*wallet.EDKeyPair, error) {
 }
 
 func TestNewMasterBIP32EDKeyPair(t *testing.T) {
-	masterKeyPair, err := generateTestMasterKeyPair()
+	// first iteration
+	keyPair1, err := generateTestMasterKeyPair()
 	require.NoError(t, err)
-	require.NotEmpty(t, masterKeyPair)
+	require.NotEmpty(t, keyPair1)
+
+	// second iteration
+	keyPair2, err := generateTestMasterKeyPair()
+	require.NoError(t, err)
+	require.NotEmpty(t, keyPair2)
 
 	msg := []byte("master test")
-	sig := ed25519.Sign(ed25519.PrivateKey(masterKeyPair.Private), msg)
-	valid := ed25519.Verify(ed25519.PublicKey(masterKeyPair.Public), msg, sig)
-	require.True(t, valid)
+
+	// Testing the private key signature generated from the first iteration and verifying with public key from the second iteration
+	sig1 := ed25519.Sign(ed25519.PrivateKey(keyPair1.Private), msg)
+	valid1 := ed25519.Verify(ed25519.PublicKey(keyPair2.Public), msg, sig1)
+	require.True(t, valid1)
+
+	// Same test with swapped private and public key
+	sig2 := ed25519.Sign(ed25519.PrivateKey(keyPair2.Private), msg)
+	valid2 := ed25519.Verify(ed25519.PublicKey(keyPair1.Public), msg, sig2)
+	require.True(t, valid2)
 }
 
 //func TestNewChildKeyPair(t *testing.T) {


### PR DESCRIPTION
Closes #35

This removes recovery dependency mentioned in issue #35 .
I am not sure whether the test in bip32_ed25519_wrapper_test.go makes sense anymore, because depndency "crypto/ed25519" does not provide api for public key extraction from signature. Only thing that is now tested is if message is signed. Maybe whole test file is no longer relevant.