### PR TITLE
Validate mnemonic whitespace

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -12,6 +12,10 @@ import (
 	"github.com/spacemeshos/smcli/common"
 )
 
+var (
+	errWhitespace = fmt.Errorf("whitespace violation in mnemonic phrase")
+)
+
 // Wallet is the basic data structure.
 type Wallet struct {
 	// keystore string
@@ -94,9 +98,8 @@ func NewMultiWalletFromMnemonic(m string, n int) (*Wallet, error) {
 	}
 
 	// bip39 lib doesn't properly validate whitespace so we have to do that manually.
-	expected := strings.Join(strings.Fields(m), " ")
-	if m != expected {
-		return nil, fmt.Errorf("whitespace violation in mnemonic phrase")
+	if expected := strings.Join(strings.Fields(m), " "); m != expected {
+		return nil, errWhitespace
 	}
 
 	// this checks the number of words and the checksum.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -12,9 +12,7 @@ import (
 	"github.com/spacemeshos/smcli/common"
 )
 
-var (
-	errWhitespace = fmt.Errorf("whitespace violation in mnemonic phrase")
-)
+var errWhitespace = fmt.Errorf("whitespace violation in mnemonic phrase")
 
 // Wallet is the basic data structure.
 type Wallet struct {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/tyler-smith/go-bip39"
 
@@ -91,11 +92,21 @@ func NewMultiWalletFromMnemonic(m string, n int) (*Wallet, error) {
 	if n < 0 || n > common.MaxAccountsPerWallet {
 		return nil, fmt.Errorf("invalid number of accounts")
 	}
+
+	// bip39 lib doesn't properly validate whitespace so we have to do that manually.
+	expected := strings.Join(strings.Fields(m), " ")
+	if m != expected {
+		return nil, fmt.Errorf("whitespace violation in mnemonic phrase")
+	}
+
+	// this checks the number of words and the checksum.
 	if !bip39.IsMnemonicValid(m) {
 		return nil, fmt.Errorf("invalid mnemonic")
 	}
+
 	// TODO: add option for user to provide passphrase
 	// https://github.com/spacemeshos/smcli/issues/18
+
 	seed := bip39.NewSeed(m, "")
 	masterKeyPair, err := NewMasterKeyPair(seed)
 	if err != nil {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -101,3 +101,19 @@ func TestKeysInWalletMaintainExpectedPath(t *testing.T) {
 		require.Equal(t, expectedPath, HDPathToString(path))
 	}
 }
+
+func TestMnemonicWhitespace(t *testing.T) {
+	mnemonics := []string{
+		"film  theme cheese broken kingdom destroy inch ready wear inspire shove pudding",
+		"film theme cheese broken kingdom destroy inch ready wear  inspire shove pudding",
+		"film theme cheese broken kingdom destroy inch ready wear\ninspire shove pudding",
+		"film theme cheese broken kingdom destroy inch ready wear inspire shove pudding\t",
+		" film theme cheese broken kingdom destroy inch ready wear inspire shove pudding",
+		"film theme cheese broken kingdom destroy inch ready wear inspire shove pudding ",
+		"film  theme  cheese  broken  kingdom  destroy  inch  ready  wear  inspire  shove  pudding",
+	}
+	for _, m := range mnemonics {
+		_, err := NewMultiWalletFromMnemonic(m, 1)
+		require.Equal(t, errWhitespace, err, "expected whitespace error in mnemonic")
+	}
+}


### PR DESCRIPTION
Closes #58 

Print an error and refuse to generate keys if a whitespace violation is detected in an input mnemonic