### PR TITLE
Show addresses

### DIFF
--- a/cmd/internal/wallet.go
+++ b/cmd/internal/wallet.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-secure-stdlib/password"
+
+	"github.com/spacemeshos/smcli/wallet"
+)
+
+// LoadWallet from a file, asks for the password from stdin.
+func LoadWallet(path string, debug bool) (*wallet.Wallet, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer f.Close()
+
+	fmt.Print("Enter wallet password: ")
+	pass, err := password.Read(os.Stdin)
+	fmt.Println()
+	if err != nil {
+		return nil, err
+	}
+
+	wk := wallet.NewKey(wallet.WithPasswordOnly([]byte(pass)))
+
+	w, err := wk.Open(f, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/btcsuite/btcutil v1.0.2
+	github.com/cosmos/btcutil v1.0.5
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/go-spacemesh v1.0.2
@@ -15,7 +16,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/c0mm4nd/go-ripemd v0.0.0-20200326052756-bd1759ad7d10 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/go-llsqlite/llsqlite v0.0.0-20230612031458-a9e271fe723a // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect


### PR DESCRIPTION
- Show address in `wallet read` (can be hidden with `--no-address`).
- Show public and private key in bech32 format for the `wallet read` command. (Use `--hex` for the old format)
- New command `wallet address` showing the address of a wallet.

Note: This PR does not close the issue #38  as it is a temporary fix and does not implement the required logic in Rust as [discussed](https://github.com/spacemeshos/smcli/issues/38#issuecomment-1633008674).