### PR TITLE
Added dockerized build compatible with debian 11 (and Tails 5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+smcli
+tails
+.git
+.github
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bullseye as build-stage
+ARG GOLANG_INSTALL=https://go.dev/dl/go1.20.6.linux-amd64.tar.gz
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libudev-dev ca-certificates curl
+
+RUN update-ca-certificates
+
+RUN curl -L ${GOLANG_INSTALL} | tar -C /usr/local -xzf -
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+RUN adduser --disabled-password --gecos '' spacemesh 
+COPY --chown=spacemesh . /home/spacemesh 
+USER spacemesh
+WORKDIR /home/spacemesh
+
+RUN make build
+
+FROM scratch as export-stage
+COPY --from=build-stage /home/spacemesh/smcli /

--- a/Makefile
+++ b/Makefile
@@ -164,5 +164,9 @@ staticcheck: $(UNZIP_DEST)
 	LD_LIBRARY_PATH=$(REAL_DEST) \
 	staticcheck ./...
 
+.PHONY: tails
+tails:
+	docker build -o tails .
+
 clean:
 	rm -rf $(UNZIP_DEST)


### PR DESCRIPTION
Running "make tails" will run a build inside a debian-11 docker container, and output the binary in the "Tails" subdirectory. 
This binary can be run on  a system running Tails 5.