### PR TITLE
Replace boilerplate cobra text for "wallet" command

### DIFF
--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -45,13 +45,7 @@ var (
 // walletCmd represents the wallet command.
 var walletCmd = &cobra.Command{
 	Use:   "wallet",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Wallet management",
 }
 
 // createCmd represents the create command.


### PR DESCRIPTION
Remove some left-over boilerplate text generated by cobra